### PR TITLE
DescomplicandoKubernetes - 3 (Update README.md) - add new information about rollback

### DIFF
--- a/DescomplicandoKubernetes/day-3/README.md
+++ b/DescomplicandoKubernetes/day-3/README.md
@@ -818,6 +818,9 @@ Pod Template:
 
 Ou seja, como podemos notar, a revisão 1 é a versão 1.16.0 do Nginx e a revisão 2 é a versão 1.15.0 do Nginx.
 
+__OBSERVAÇÃO IMPORTANTE: O comando de rollback através do `rollout undo` afeta somente as configurações a nível de Pod. As configurações feitas a nivel de Deploy (como Replicas e Labels) não são afetadas neste comando e permanessem inalteradas.__
+
+
 Se você quiser fazer o rollback para a revisão 1, basta executar o seguinte comando:
 
 ```bash


### PR DESCRIPTION
Nos meus estudos tive uma duvida que foi sanada na mesma aula do treinamento DescomplicandoKubernetes ...

Pessoal, quando estava fazendo a aula (Fazendo Rollback e conhecendo o comando Rollout) no minuto 2:40 o @Badtuxx fez o rollback do deployment (kubectl rollout undo deployment -n giropops nginx-deployment) para voltar para o deploy anterior. 

No primeiro momento eu pensei que o "rollout undo" faria o rollback do "Deploy Inteiro", porem no minuto 4:02, ao fazer o describe mostrou que as alterações feitas nas informações do Deploy ( como as Labels e as Replicas) permaneceram. 

No minuto 6:17 que eu entendi que na verdade o rollout cuida somente das configurações a nivel de Pod.

Achei valido trazer essa informação porque me foi muito importante.

---
na Documentação está sendo falado dobre isso... atente a Nota:

https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-back-a-deployment